### PR TITLE
isMemberOfClass fails with jitter server objects

### DIFF
--- a/SyphonNameboundClient.m
+++ b/SyphonNameboundClient.m
@@ -216,7 +216,8 @@
     // This deals with a change in notifications from Syphon.
     // Once all projects using SyphonNameboundClient are updated to newer Syphon.framework
     // we won't need this method and can always use notification.userInfo.
-    if ([notification.object isKindOfClass:[SyphonServerDirectory class]])
+    //if ([notification.object isMemberOfClass:[SyphonServerDirectory class]])
+	if ([notification.userInfo objectForKey:SyphonServerDescriptionUUIDKey] != nil)
     {
         return notification.userInfo;
     }


### PR DESCRIPTION
hey Tom, I'm updating the jitter objects for core profile support, and I was getting a crash in the jitter-client whenever jitter-server objects are added or removed. it seems like isMemberOfClass failed here, possibly due to the @compatibility_alias ?

my change fixes the crash, but I don't know enough about the codebase to know if this is correct. thanks for taking a look!